### PR TITLE
Logger Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Lightweight rule engine, written in typescript
 - [x] One time rule execution in sequence
 - [x] Rule weight for priority
 - [x] Supports ESM and CommonJS
+- [x] Logger interface for custom logging
 
 ## Installation
 
@@ -137,3 +138,68 @@ console.log(fact)
 }
 */
 ```
+
+### 4. Using the Rule Engine with Logger
+
+The example below shows how to use the rule engine with a custom logger. The logger should implement the Logger interface. If a logger is not provided, logs are written using the global `console` object.
+
+```typescript
+import { RuleEngine, Logger } from 'ts-rule-engine'
+
+/* Define fact */
+const fact: Fact = {
+  application: 'ts-rule-engine',
+  cost: 0,
+  license: '',
+  description: ''
+}
+
+/* Define rule */
+const rule: Rule<Fact> = {
+  condition: (fact) => {
+    return fact.cost === 0
+  },
+  action: (fact, { logger }) => {
+    logger.info('All Good')
+    fact.license = 'MIT'
+    fact.description = 'License originating at the Massachusetts Institute of Technology (MIT) in the late 1980s'
+    fact.stop()
+  },
+};
+
+/* Custom Logger */
+class CustomLogger implements Logger {
+  messages: string[] = []
+
+  info(message?: string, ...optionalParams: string[]): void {
+    this.messages.push(message)
+  }
+
+  warn(message?: string, ...optionalParams: string[]): void {
+    this.messages.push(message)
+  }
+
+  error(message?: string, ...optionalParams: string[]): void {
+    this.messages.push(message)
+  }
+}
+
+/* Creating Rule Engine instance */
+const logger = new CustomLogger()
+const engine = new RuleEngine(fact, {logger})
+engine.addRule(rule)
+/* For multiple rules, use engine.addRules(rules) */
+await engine.run()
+
+// Check logger messages
+console.log(logger.messages)
+/*
+[
+  'Rule 1: Executing',
+  'Rule 1: Executed',
+  'Rule 1: Stopped'
+]
+*/
+
+```
+

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,74 @@
+import { RuleEngine } from '../src/rules'
+import type { Rule } from '../src/rules'
+import type { Logger } from '../src/rules'
+
+interface Fact {
+  counter: number
+}
+
+class LogSink implements Logger {
+  messages: string[] = []
+
+  info(message?: string): void {
+    this.messages.push(message)
+  }
+
+  warn(message?: string): void {
+    this.messages.push(message)
+  }
+
+  error(message?: string): void {
+    this.messages.push(message)
+  }
+}
+
+const rule: Rule<Fact> = {
+  id: 'always increment',
+  weight: 1,
+  condition: (fact: Fact, { logger }) => {
+    logger.info('Always true')
+    return true
+  },
+  action: (fact: Fact, { stop, logger }) => {
+    fact.counter++
+    logger.info('Incremented counter')
+    stop()
+  },
+}
+
+describe('Logger', function () {
+  it('logs to console if a logger is not provided in the options', async () => {
+    const consoleSpy = jest.spyOn(global.console, 'info')
+    const fact: Fact = {
+      counter: 0,
+    }
+
+    const engine = new RuleEngine(fact)
+    engine.addRule(rule)
+    await engine.run()
+
+    expect(fact.counter).toBe(1)
+    expect(consoleSpy).toHaveBeenCalledTimes(4)
+  })
+
+  it('logs to logger if a logger is provided in the options', async () => {
+    const consoleSpy = jest.spyOn(global.console, 'info')
+    const fact: Fact = {
+      counter: 0,
+    }
+
+    const logger = new LogSink()
+
+    const engine = new RuleEngine(fact, { logger })
+    engine.addRule(rule)
+    await engine.run()
+
+    expect(fact.counter).toBe(1)
+    expect(logger.messages).toHaveLength(4)
+    expect(logger.messages[0]).toBe('Always true')
+    expect(logger.messages[1]).toBe('Evaluating rule: always increment (condition met)')
+    expect(logger.messages[2]).toBe('Incremented counter')
+    expect(logger.messages[3]).toBe('Termination condition met based on action.')
+    expect(consoleSpy).toHaveBeenCalledTimes(0)
+  })
+})


### PR DESCRIPTION
Provide support for a custom Logger to support logging to implementation specific log targets. 

Additions:

- Logger interface that mimics the global `console` object
- inject Logger into Rule `condition` and `action` methods  during execution
- Use console to log if no Logger is provided using `RuleEngineOptions`

Checks:

- [x] Test added
- [x] Documentation updated
- [x] Lint rules applied
